### PR TITLE
Add simple TypeScript weather app

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,39 @@
+"use strict";
+function getWeather(lat, lon) {
+    var url = "https://api.open-meteo.com/v1/forecast?latitude=".concat(lat, "&longitude=").concat(lon, "&current_weather=true");
+    fetch(url)
+        .then(function (resp) { return resp.json(); })
+        .then(function (data) {
+        var container = document.getElementById('weather');
+        if (container && data.current_weather) {
+            container.innerHTML = "\n          <h2>Current Weather</h2>\n          <p>Temperature: ".concat(data.current_weather.temperature, "&deg;C</p>\n          <p>Wind Speed: ").concat(data.current_weather.windspeed, " km/h</p>\n          <p>Time: ").concat(data.current_weather.time, "</p>\n        ");
+        }
+    })
+        .catch(function (err) {
+        var container = document.getElementById('weather');
+        if (container)
+            container.innerText = 'Error fetching weather data';
+        console.error(err);
+    });
+}
+function init() {
+    var container = document.getElementById('weather');
+    if (container)
+        container.innerText = 'Fetching location...';
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(function (pos) {
+            var _a = pos.coords, latitude = _a.latitude, longitude = _a.longitude;
+            if (container)
+                container.innerText = 'Fetching weather...';
+            getWeather(latitude, longitude);
+        }, function () {
+            if (container)
+                container.innerText = 'Location access denied';
+        });
+    }
+    else {
+        if (container)
+            container.innerText = 'Geolocation is not supported by your browser';
+    }
+}
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Weather App</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    #weather { margin: 20px; }
+  </style>
+</head>
+<body>
+  <div id="weather">Loading...</div>
+  <script src="dist/index.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",
@@ -15,5 +16,8 @@
     "url": "https://github.com/rikotsev/videcode-test-1/issues"
   },
   "homepage": "https://github.com/rikotsev/videcode-test-1#readme",
-  "description": ""
+  "description": "",
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,53 @@
+interface WeatherData {
+  current_weather: {
+    temperature: number;
+    windspeed: number;
+    winddirection: number;
+    weathercode: number;
+    is_day: number;
+    time: string;
+  };
+}
+
+function getWeather(lat: number, lon: number) {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true`;
+  fetch(url)
+    .then(resp => resp.json())
+    .then((data: WeatherData) => {
+      const container = document.getElementById('weather');
+      if (container && data.current_weather) {
+        container.innerHTML = `
+          <h2>Current Weather</h2>
+          <p>Temperature: ${data.current_weather.temperature}&deg;C</p>
+          <p>Wind Speed: ${data.current_weather.windspeed} km/h</p>
+          <p>Time: ${data.current_weather.time}</p>
+        `;
+      }
+    })
+    .catch(err => {
+      const container = document.getElementById('weather');
+      if (container) container.innerText = 'Error fetching weather data';
+      console.error(err);
+    });
+}
+
+function init() {
+  const container = document.getElementById('weather');
+  if (container) container.innerText = 'Fetching location...';
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        if (container) container.innerText = 'Fetching weather...';
+        getWeather(latitude, longitude);
+      },
+      () => {
+        if (container) container.innerText = 'Location access denied';
+      }
+    );
+  } else {
+    if (container) container.innerText = 'Geolocation is not supported by your browser';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es5",
+    "module": "es2015",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript configuration and build step
- implement a small weather app that fetches data from Open-Meteo using user location
- include HTML page that loads the compiled script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e62cfad708329a530f468da7ba3e2